### PR TITLE
Fix BOM issue while parsing the file

### DIFF
--- a/apps/csv2sql/lib/csv2sql/data_transfer.ex
+++ b/apps/csv2sql/lib/csv2sql/data_transfer.ex
@@ -13,7 +13,7 @@ defmodule Csv2sql.DataTransfer do
     insertion_chunk_size = Application.get_env(:csv2sql, Csv2sql.get_repo())[:insertion_chunk_size]
 
     file
-    |> File.stream!()
+    |> File.stream!([:trim_bom])
     |> CSV.parse_stream()
     |> Stream.chunk_every(insertion_chunk_size)
     |> Enum.each(fn data_chunk ->

--- a/apps/csv2sql/lib/csv2sql/database.ex
+++ b/apps/csv2sql/lib/csv2sql/database.ex
@@ -142,7 +142,7 @@ defmodule Csv2sql.Database do
   defp get_headers(file) do
     [headers] =
       file
-      |> File.stream!()
+      |> File.stream!([:trim_bom])
       |> Stream.take(1)
       |> CSV.parse_stream(skip_headers: false)
       |> Enum.to_list()

--- a/apps/csv2sql/lib/csv2sql/import_validator.ex
+++ b/apps/csv2sql/lib/csv2sql/import_validator.ex
@@ -52,7 +52,7 @@ defmodule Csv2sql.ImportValidator do
   """
   def get_count_from_csv(file) do
     file
-    |> File.stream!()
+    |> File.stream!([:trim_bom])
     |> CSV.parse_stream()
     |> Enum.count()
   end

--- a/apps/csv2sql/lib/csv2sql/schema_maker.ex
+++ b/apps/csv2sql/lib/csv2sql/schema_maker.ex
@@ -106,7 +106,7 @@ defmodule Csv2sql.SchemaMaker do
 
     types =
       path
-      |> File.stream!()
+      |> File.stream!([:trim_bom])
       |> CSV.parse_stream()
       |> Stream.chunk_every(schema_infer_chunk_size)
       |> Task.async_stream(__MODULE__, :infer_type, [headers_type_list],
@@ -171,7 +171,7 @@ defmodule Csv2sql.SchemaMaker do
   defp get_headers(path) do
     [headers] =
       path
-      |> File.stream!()
+      |> File.stream!([:trim_bom])
       |> Stream.take(1)
       |> CSV.parse_stream(skip_headers: false)
       |> Enum.to_list()


### PR DESCRIPTION
-Trim BOM while creating the file stream else it will raise error if any csv files contains BOM.
If you pass :trim_bom in the modes parameter, the stream will trim UTF-8, UTF-16 and UTF-32 byte order marks when reading from file.
Note that this function does not try to discover the file encoding basing on BOM.